### PR TITLE
#169257968 Avoid sending emails when running automated tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,8 @@ LOG_LEVEL=<the desired log level>
 MAILGUN_API_KEY=<mailgun api key>
 MAILGUN_DOMAIN=<mailgun api domain>
 
-TEST_EMAIL=<email to use for testing purpose>
+# When running automated tests, email notifications won't be sent, 
+# use this environment variable to override that behaviour by setting it to true.
+ENFORCE_TEST_EMAILS=<true>
 
 JWT_SECRETE=<just any random string>

--- a/src/services/config.js
+++ b/src/services/config.js
@@ -10,7 +10,6 @@ export default {
   },
   email: {
     noReply: 'no-reply@realdrip.com',
-    testEmail: process.env.TEST_EMAIL,
   },
   jwtSecrete: process.env.JWT_SECRETE,
   serverAppUrl: process.env.SERVER_APP_URL,


### PR DESCRIPTION
#### What does this PR do?
- Implement logic to avoid sending emails during automated tests
- Added an environment variable to toggle the behavior of sending emails during automated tests
- Remove the use of test email environment variable