### PR TITLE
#169258192 authMiddleware to give specific error for expired token

### DIFF
--- a/src/http/middlewares/authMiddleware.js
+++ b/src/http/middlewares/authMiddleware.js
@@ -15,6 +15,9 @@ const auth = async (req, res, next) => {
     res.locals.user = user;
     res.locals.userType = type;
   } catch (err) {
+    if (err.name === 'TokenExpiredError') {
+      return res.status(401).json({ success: false, message: 'Token expired' });
+    }
     return res.status(401).json({ success: false, message: 'Unable to authenticate token' });
   }
   return next();


### PR DESCRIPTION
#### WHAT DOES THIS PR DO
- Give an `expired token` error instead of the generic `Unable to authenticate token` error when the request token is expired

#### RELEVANT PT STORY
- [#169258192](https://www.pivotaltracker.com/story/show/169258192)