### PR TITLE
#169891452 Abstract the logic behind creating service error

### DIFF
--- a/src/services/serviceError.js
+++ b/src/services/serviceError.js
@@ -1,0 +1,7 @@
+export default class ServiceError extends Error {
+  constructor(message, httpStatusCode) {
+    super();
+    this.message = message;
+    this.httpStatusCode = httpStatusCode;
+  }
+}

--- a/src/services/user/allUser.js
+++ b/src/services/user/allUser.js
@@ -2,6 +2,7 @@ import bcrypt from 'bcrypt';
 import jwt from 'jsonwebtoken';
 import db from '../../db';
 import config from '../config';
+import ServiceError from '../serviceError';
 
 /**
  * @description Format the user data to be returned to the client
@@ -37,9 +38,7 @@ const login = async (data, log) => {
   const user = await db.users.getUser({ email: email.toLowerCase() }, userType);
   if (!user || !bcrypt.compareSync(password, user.password)) {
     log.debug('The given email or password is not correct, throwing error');
-    const error = new Error('Email or password incorrect');
-    error.httpStatusCode = 400;
-    throw error;
+    throw new ServiceError('Email or password incorrect', 400);
   }
   const userId = user._id;
   log.debug('Create an auth token for this user');
@@ -65,15 +64,11 @@ const updatePassword = async (data, log) => {
   const user = await db.users.getUser({ _id: userId }, userType);
   if (!user) {
     log.debug('The user to update does not exist');
-    const error = new Error('User does not exist');
-    error.httpStatusCode = 404;
-    throw error;
+    throw new ServiceError('User does not exist', 404);
   }
   if (!bcrypt.compareSync(formerPassword, user.password)) {
     log.debug('The formerPassword is not correct, throwing error');
-    const error = new Error('Former password is not correct');
-    error.httpStatusCode = 400;
-    throw error;
+    throw new ServiceError('Former password is not correct', 400);
   }
   log.debug('Hashing new user password');
   const newHashedPassword = await bcrypt.hash(newPassword, 10);

--- a/src/services/user/allUser.js
+++ b/src/services/user/allUser.js
@@ -38,7 +38,7 @@ const login = async (data, log) => {
   const user = await db.users.getUser({ email: email.toLowerCase() }, userType);
   if (!user || !bcrypt.compareSync(password, user.password)) {
     log.debug('The given email or password is not correct, throwing error');
-    throw new ServiceError('Incorrect Email or passwrod', 400);
+    throw new ServiceError('Incorrect email or password', 400);
   }
   const userId = user._id;
   log.debug('Create an auth token for this user');

--- a/src/services/user/allUser.js
+++ b/src/services/user/allUser.js
@@ -38,7 +38,7 @@ const login = async (data, log) => {
   const user = await db.users.getUser({ email: email.toLowerCase() }, userType);
   if (!user || !bcrypt.compareSync(password, user.password)) {
     log.debug('The given email or password is not correct, throwing error');
-    throw new ServiceError('Email or password incorrect', 400);
+    throw new ServiceError('Incorrect Email or passwrod', 400);
   }
   const userId = user._id;
   log.debug('Create an auth token for this user');

--- a/src/services/user/hospitalUser.js
+++ b/src/services/user/hospitalUser.js
@@ -3,6 +3,7 @@ import jwt from 'jsonwebtoken';
 import db from '../../db';
 import emailService from '../email';
 import config from '../config';
+import ServiceError from '../serviceError';
 
 /**
  * @description Format the user data to be returned to the client
@@ -38,9 +39,7 @@ const createAdminUser = async (data, log) => {
   );
   if (alreadyExistingUser) {
     log.debug('User with the given email already exist, throwing error');
-    const error = new Error('User with this email already exist');
-    error.httpStatusCode = 409;
-    throw error;
+    throw new ServiceError('User with this email already exist', 409);
   }
   log.debug('Hashing user password');
   const hashedPassword = await bcrypt.hash(password, config.bcryptHashSaltRounds);
@@ -99,9 +98,7 @@ const confirmUserAccount = async (regToken, log) => {
     return db.users.updateUser({ email }, { confirmedEmail: true }, userType);
   } catch (err) {
     log.debug('Unable to verify the registeration token, throwing error');
-    const error = new Error('Registeration token not valid');
-    error.httpStatusCode = 400;
-    throw error;
+    throw new ServiceError('Registeration token not valid', 400);
   }
 };
 

--- a/src/services/user/nurseUser.js
+++ b/src/services/user/nurseUser.js
@@ -3,6 +3,7 @@ import bcrypt from 'bcrypt';
 import config from '../config';
 import db from '../../db';
 import emailService from '../email';
+import ServiceError from '../serviceError';
 
 /**
  * @description Format the user data to be returned to the client
@@ -40,9 +41,7 @@ const createNurseUser = async (data, log) => {
   );
   if (alreadyExistingUser) {
     log.debug('Nurse user with the given email already exist, throwing error');
-    const error = new Error('Nurse user with this email already exist');
-    error.httpStatusCode = 409;
-    throw error;
+    throw new ServiceError('Nurse user with this email already exist', 409);
   }
   log.debug('Creating a default password for this user');
   const defaultPassword = passwordGenerator.generate({ length: 10, numbers: true });

--- a/src/services/user/wardUser.js
+++ b/src/services/user/wardUser.js
@@ -3,6 +3,7 @@ import bcrypt from 'bcrypt';
 import config from '../config';
 import db from '../../db';
 import emailService from '../email';
+import ServiceError from '../serviceError';
 
 /**
  * @description Format the user data to be returned to the client
@@ -38,9 +39,7 @@ const createWardUser = async (data, log) => {
   );
   if (alreadyExistingUser) {
     log.debug('Ward user with the given email already exist, throwing error');
-    const error = new Error('Ward user with this email already exist');
-    error.httpStatusCode = 409;
-    throw error;
+    throw new ServiceError('Ward user with this email already exist', 409);
   }
   log.debug('Creating a default password for this user');
   const defaultPassword = passwordGenerator.generate({ length: 10, numbers: true });

--- a/src/tests/users/login.test.js
+++ b/src/tests/users/login.test.js
@@ -86,7 +86,7 @@ const testCases = [
       status: 400,
       body: {
         success: false,
-        message: 'Email or password incorrect',
+        message: 'Incorrect email or password',
       },
     },
   },
@@ -119,7 +119,7 @@ const testCases = [
       status: 400,
       body: {
         success: false,
-        message: 'Email or password incorrect',
+        message: 'Incorrect email or password',
       },
     },
   },


### PR DESCRIPTION
Instead of doing this every time we want to throw an error within a service:
```
const error = new Error('');	
error.httpStatusCode = ***;	
throw error;
```
We can abstract these details behind a `ServiceError` class, and then do this:
```
throw ServiceError(message, httpStatusCode)
```
This PR implements and use the `ServiceError` class.