### PR TITLE
#169257930 Implement send-email-validation endpoint

### DIFF
--- a/src/http/controllers/user/hospitalUser.js
+++ b/src/http/controllers/user/hospitalUser.js
@@ -47,8 +47,21 @@ const confirmUserAccount = catchControllerError('ConfirmUserAccount', async (req
   return res.status(302).redirect(`${config.clientAppUrl}/login`);
 });
 
+/**
+ * @description Controller for sendEmailValidationMail mail API operation
+ * @param {object} req Express request object
+ * @param {object} res Express response object
+ */
+const sendEmailValidationMail = catchControllerError('sendEmailValidationMail', async (req, res) => {
+  const { log, user: { name, email } } = res.locals;
+  await hospitalUserService.sendEmailValidationMail({ name, email }, log);
+  log.debug('sendEmailValidationMail service executed without error, sending back a success response');
+  return res.status(200).json({ success: true, message: 'Email address validation mail sent' });
+});
+
 export default {
   createAdminUser: [userValidation.createAdminUser, createAdminUser],
   confirmUserAccount: [userValidation.validateRegToken, confirmUserAccount],
   updateAdminUser: [userValidation.updateHospitalUser, updateAdminUser],
+  sendEmailValidationMail,
 };

--- a/src/http/routes.js
+++ b/src/http/routes.js
@@ -22,6 +22,13 @@ router.put(
 router.get('/hospital/confirmEmail', controllers.hospitalUser.confirmUserAccount);
 
 router.post(
+  '/hospital/sendEmailValidationMail',
+  authMiddleware,
+  hasUserPrivledge([HOSPITAL_ADMIN_USER.toLowerCase()]),
+  controllers.hospitalUser.sendEmailValidationMail,
+);
+
+router.post(
   '/ward',
   authMiddleware,
   hasUserPrivledge([HOSPITAL_ADMIN_USER.toLowerCase()]),

--- a/src/tests/users/hospital/sendEmailValidationMail.test.js
+++ b/src/tests/users/hospital/sendEmailValidationMail.test.js
@@ -1,0 +1,45 @@
+import db from '../../../db';
+import testRunner from '../../utils/testRunner';
+import confirmAccessLevelRestriction from '../../genericTestCases/confirmAccessLevelRestriction';
+import confirmAuthRestriction from '../../genericTestCases/confirmAuthRestriction';
+
+const { WARD_USER, NURSE_USER, HOSPITAL_ADMIN_USER } = db.users.userTypes;
+
+const testCases = [
+  {
+    title: 'should send email address validation mail',
+    request: context => ({
+      method: 'post',
+      path: '/api/hospital/sendEmailValidationMail',
+      headers: {
+        'req-token': context.testGlobals[HOSPITAL_ADMIN_USER].authToken,
+      },
+    }),
+    response: {
+      status: 200,
+      body: {
+        success: true,
+        message: 'Email address validation mail sent',
+      },
+    },
+  },
+  confirmAccessLevelRestriction({
+    title: 'ward user should not be access this endpoint',
+    userType: WARD_USER,
+    path: '/api/hospital/sendEmailValidationMail',
+    method: 'post',
+  }),
+  confirmAccessLevelRestriction({
+    title: 'nurse user should not be access this endpoint',
+    userType: NURSE_USER,
+    path: '/api/hospital/sendEmailValidationMail',
+    method: 'post',
+  }),
+  confirmAuthRestriction({
+    title: 'should fail if user does not send a valid auth token',
+    path: '/api/hospital/sendEmailValidationMail',
+    method: 'post',
+  }),
+];
+
+testRunner(testCases, 'Send email address validation mail', {});


### PR DESCRIPTION
### What does this PR do?
- Implement send-email-validation endpoint. This endpoint can be used to resend validation mail just in case the user missed it the first time it was sent i.e after creating an account

### Related pivotal tracker story?
[#169257930](https://www.pivotaltracker.com/story/show/169257930)