### PR TITLE
#170123427 use volumeToDispense instead of start stop volumes

### DIFF
--- a/src/db/infusion/index.js
+++ b/src/db/infusion/index.js
@@ -3,8 +3,7 @@ import infusionModel from './model';
 /**
  * @description Creates an infusion in the database
  * @param {object} data  The infusion details
- * @param {number} data.startVolume The start volume
- * @param {number} data.stopVolume The stop volume
+ * @param {number} data.volumeToDispense The volume to be administered
  * @param {string} data.patientName The patient's name
  * @param {string} data.doctorsInstruction Doctors Instruction
  * @param {string} data.status Infusion status

--- a/src/db/infusion/model.js
+++ b/src/db/infusion/model.js
@@ -3,8 +3,7 @@ import mongoose from 'mongoose';
 const { Schema } = mongoose;
 
 const infusionSchema = new Schema({
-  startVolume: { type: Number, required: true },
-  stopVolume: { type: Number, required: true },
+  volumeToDispense: { type: Number, required: true },
   patientName: { type: String, required: true },
   doctorsInstruction: { type: String, required: true },
   status: { type: String, enum: ['active', 'ended'] },

--- a/src/http/controllers/infusion.js
+++ b/src/http/controllers/infusion.js
@@ -19,12 +19,11 @@ const getPopulateFields = (populateQueryParams) => {
  */
 const createInfusion = catchControllerError('CreateInfusion', async (req, res) => {
   const {
-    patientName, doctorsInstruction, startVolume, stopVolume, deviceId,
+    patientName, doctorsInstruction, volumeToDispense, deviceId,
   } = req.body;
   const { user, userType, log } = res.locals;
   const infusion = await infusionService.createInfusion({
-    startVolume,
-    stopVolume,
+    volumeToDispense,
     patientName,
     doctorsInstruction,
     deviceId,
@@ -74,12 +73,12 @@ const getSingleInfusion = catchControllerError('GetSingleInfusion', async (req, 
  */
 const updateInfusion = catchControllerError('UpdateInfusion', async (req, res) => {
   const {
-    patientName, doctorsInstruction, startVolume, stopVolume,
+    patientName, doctorsInstruction, volumeToDispense,
   } = req.body;
   const { infusionId } = req.params;
   const { user, userType, log } = res.locals;
   const infusion = await infusionService.updateInfusion({
-    infusionId, user, userType, patientName, doctorsInstruction, startVolume, stopVolume,
+    infusionId, user, userType, patientName, doctorsInstruction, volumeToDispense,
   }, log);
   if (!infusion) {
     return res.status(404).json({ success: false, message: 'Infusion not found' });

--- a/src/http/validations/infusion.js
+++ b/src/http/validations/infusion.js
@@ -3,14 +3,13 @@ import db from '../../db';
 
 const createInfusion = (req, res, next) => {
   const {
-    patientName, doctorsInstruction, startVolume, stopVolume, deviceId,
+    patientName, doctorsInstruction, volumeToDispense, deviceId,
   } = req.body;
   const fieldErrors = new FieldErrors();
 
   if (!patientName || typeof (patientName) !== 'string') fieldErrors.addError('patientName', 'patientName is a required string');
   if (!doctorsInstruction || typeof (doctorsInstruction) !== 'string') fieldErrors.addError('doctorsInstruction', 'doctorsInstruction is a required string');
-  if (!startVolume || typeof (startVolume) !== 'number') fieldErrors.addError('startVolume', 'startVolume is a required number');
-  if (!stopVolume || typeof (stopVolume) !== 'number') fieldErrors.addError('stopVolume', 'stopVolume is a required number');
+  if (!volumeToDispense || typeof (volumeToDispense) !== 'number') fieldErrors.addError('volumeToDispense', 'volumeToDispense is a required number');
   if (!deviceId || typeof (deviceId) !== 'string') fieldErrors.addError('deviceId', 'deviceId is required');
   else if (!db.validResourceId(deviceId)) fieldErrors.addError('deviceId', 'Invalid deviceId');
   if (fieldErrors.count > 0) {
@@ -35,7 +34,7 @@ const validateInfusionId = (req, res, next) => {
 const updateInfusion = (req, res, next) => {
   const { infusionId } = req.params;
   const {
-    patientName, doctorsInstruction, startVolume, stopVolume,
+    patientName, doctorsInstruction, volumeToDispense,
   } = req.body;
   const fieldErrors = new FieldErrors();
 
@@ -47,11 +46,8 @@ const updateInfusion = (req, res, next) => {
   if (doctorsInstruction) {
     if (typeof (doctorsInstruction) !== 'string') fieldErrors.addError('doctorsInstruction', 'doctorsInstruction is a required string');
   }
-  if (startVolume) {
-    if (typeof (startVolume) !== 'number') fieldErrors.addError('startVolume', 'startVolume is a required number');
-  }
-  if (stopVolume) {
-    if (typeof (stopVolume) !== 'number') fieldErrors.addError('stopVolume', 'stopVolume is a required number');
+  if (volumeToDispense) {
+    if (typeof (volumeToDispense) !== 'number') fieldErrors.addError('volumeToDispense', 'volumeToDispense is a required number');
   }
   if (req.body.constructor === Object && Object.keys(req.body).length === 0) {
     return res.status(400).json({ success: false, message: 'Invalid request: All fields can\'t be empty' });

--- a/src/services/infusion.js
+++ b/src/services/infusion.js
@@ -3,8 +3,7 @@ import db from '../db';
 const createInfusion = async (data, log) => {
   log.debug('Executing createInfusion service');
   const {
-    startVolume,
-    stopVolume,
+    volumeToDispense,
     patientName,
     doctorsInstruction,
     deviceId,
@@ -13,8 +12,7 @@ const createInfusion = async (data, log) => {
   } = data;
   log.debug('Gathering data for creating Infusion');
   const infusionDetails = {
-    startVolume,
-    stopVolume,
+    volumeToDispense,
     patientName,
     doctorsInstruction,
     deviceId,
@@ -99,7 +97,7 @@ const getSingleInfusion = async (data, log) => {
  */
 const updateInfusion = async (data, log) => {
   const {
-    infusionId, user, userType, patientName, doctorsInstruction, startVolume, stopVolume,
+    infusionId, user, userType, patientName, doctorsInstruction, volumeToDispense,
   } = data;
   const infusionMatch = {
     _id: infusionId,
@@ -109,7 +107,7 @@ const updateInfusion = async (data, log) => {
   };
   const purifyInfusionMatch = JSON.parse(JSON.stringify(infusionMatch));
   const update = JSON.parse(JSON.stringify({
-    patientName, doctorsInstruction, startVolume, stopVolume,
+    patientName, doctorsInstruction, volumeToDispense,
   }));
   log.debug('Updating infusion details');
   const infusion = await db.infusion.updateInfusion(

--- a/src/tests/infusion/createInfusion.test.js
+++ b/src/tests/infusion/createInfusion.test.js
@@ -97,7 +97,7 @@ const testCases = [
     },
   },
   {
-    title: 'creation of infusion should fail if the volumeToDispense is not a numbers',
+    title: 'creation of infusion should fail if the volumeToDispense is not a number',
     request: context => ({
       path: '/api/infusion',
       method: 'post',

--- a/src/tests/infusion/createInfusion.test.js
+++ b/src/tests/infusion/createInfusion.test.js
@@ -6,8 +6,7 @@ import confirmAuthRestriction from '../genericTestCases/confirmAuthRestriction';
 const { WARD_USER, NURSE_USER } = db.users.userTypes;
 
 const infusion = {
-  startVolume: 700,
-  stopVolume: 50,
+  volumeToDispense: 700,
   patientName: 'Tumtum',
   doctorsInstruction: 'This is the doctor\'s instructions and it\'s a string',
   deviceId: '5db95971c9da2412401b1804',
@@ -42,8 +41,7 @@ const testCases = [
         message: 'Infusion created',
         data: {
           _id: expect.any(String),
-          startVolume: infusion.startVolume,
-          stopVolume: infusion.stopVolume,
+          volumeToDispense: infusion.volumeToDispense,
           patientName: infusion.patientName,
           doctorsInstruction: infusion.doctorsInstruction,
           deviceId: infusion.deviceId,
@@ -70,8 +68,7 @@ const testCases = [
         message: 'Invalid request',
         errors: {
           patientName: ['patientName is a required string'],
-          startVolume: ['startVolume is a required number'],
-          stopVolume: ['stopVolume is a required number'],
+          volumeToDispense: ['volumeToDispense is a required number'],
           doctorsInstruction: ['doctorsInstruction is a required string'],
           deviceId: ['deviceId is required'],
         },
@@ -100,11 +97,11 @@ const testCases = [
     },
   },
   {
-    title: 'creation of infusion should fail if the start and stop volumes are not numbers',
+    title: 'creation of infusion should fail if the volumeToDispense is not a numbers',
     request: context => ({
       path: '/api/infusion',
       method: 'post',
-      body: { ...infusion, startVolume: '700ml', stopVolume: '100ml' },
+      body: { ...infusion, volumeToDispense: '100ml' },
       headers: {
         'req-token': context.testGlobals[WARD_USER].authToken,
       },
@@ -115,8 +112,7 @@ const testCases = [
         success: false,
         message: 'Invalid request',
         errors: {
-          startVolume: ['startVolume is a required number'],
-          stopVolume: ['stopVolume is a required number'],
+          volumeToDispense: ['volumeToDispense is a required number'],
         },
       },
     },

--- a/src/tests/infusion/deleteInfusion.test.js
+++ b/src/tests/infusion/deleteInfusion.test.js
@@ -10,8 +10,7 @@ const { WARD_USER, NURSE_USER } = db.users.userTypes;
 const request = supertest(app);
 
 const infusion = {
-  startVolume: 700,
-  stopVolume: 50,
+  volumeToDispense: 700,
   patientName: 'Tumtum',
   doctorsInstruction: 'This is the doctor\'s instructions and it\'s a string',
   deviceId: '5db95971c9da2412401b1804',

--- a/src/tests/infusion/getInfusion.test.js
+++ b/src/tests/infusion/getInfusion.test.js
@@ -8,8 +8,7 @@ const { WARD_USER } = db.users.userTypes;
 const request = supertest(app);
 
 const infusion = {
-  startVolume: 700,
-  stopVolume: 50,
+  volumeToDispense: 700,
   patientName: 'Tumtum',
   doctorsInstruction: 'This is the doctor\'s instructions and it\'s a string',
   deviceId: '5db95971c9da2412401b1804',
@@ -34,8 +33,7 @@ const testCases = [
         data: expect.arrayContaining([
           expect.objectContaining({
             _id: expect.any(String),
-            startVolume: infusion.startVolume,
-            stopVolume: infusion.stopVolume,
+            volumeToDispense: infusion.volumeToDispense,
             patientName: infusion.patientName,
             doctorsInstruction: infusion.doctorsInstruction,
             deviceId: infusion.deviceId,
@@ -64,8 +62,7 @@ const testCases = [
         data: expect.arrayContaining([
           expect.objectContaining({
             _id: expect.any(String),
-            startVolume: infusion.startVolume,
-            stopVolume: infusion.stopVolume,
+            volumeToDispense: infusion.volumeToDispense,
             patientName: infusion.patientName,
             doctorsInstruction: infusion.doctorsInstruction,
             deviceId: infusion.deviceId,
@@ -93,8 +90,7 @@ const testCases = [
         message: 'Infusion found',
         data: {
           _id: expect.any(String),
-          startVolume: infusion.startVolume,
-          stopVolume: infusion.stopVolume,
+          volumeToDispense: infusion.volumeToDispense,
           patientName: infusion.patientName,
           doctorsInstruction: infusion.doctorsInstruction,
           deviceId: expect.any(String),
@@ -121,8 +117,7 @@ const testCases = [
         message: 'Infusion found',
         data: {
           _id: expect.any(String),
-          startVolume: infusion.startVolume,
-          stopVolume: infusion.stopVolume,
+          volumeToDispense: infusion.volumeToDispense,
           patientName: infusion.patientName,
           doctorsInstruction: infusion.doctorsInstruction,
           deviceId: expect.any(String),

--- a/src/tests/infusion/updateInfusion.test.js
+++ b/src/tests/infusion/updateInfusion.test.js
@@ -8,8 +8,7 @@ const { WARD_USER } = db.users.userTypes;
 const request = supertest(app);
 
 const infusion = {
-  startVolume: 700,
-  stopVolume: 50,
+  volumeToDispense: 700,
   patientName: 'Tumtum',
   doctorsInstruction: 'This is the doctor\'s instructions and it\'s a string',
   deviceId: '5db23403347ab06cc7bfd8a2',
@@ -34,8 +33,7 @@ const testCases = [
         message: 'Infusion updated',
         data: {
           _id: expect.any(String),
-          startVolume: infusion.startVolume,
-          stopVolume: infusion.stopVolume,
+          volumeToDispense: infusion.volumeToDispense,
           patientName: 'JP Saxe',
           doctorsInstruction: infusion.doctorsInstruction,
           deviceId: infusion.deviceId,
@@ -108,8 +106,7 @@ const testCases = [
       path: `/api/infusion/${context.infusionId}`,
       method: 'put',
       body: {
-        startVolume: '700ml',
-        stopVolume: '50ml',
+        volumeToDispense: '700ml',
         patientName: 25,
         doctorsInstruction: 989,
       },
@@ -124,8 +121,7 @@ const testCases = [
         message: 'Invalid request',
         errors: {
           patientName: ['patientName is a required string'],
-          startVolume: ['startVolume is a required number'],
-          stopVolume: ['stopVolume is a required number'],
+          volumeToDispense: ['volumeToDispense is a required number'],
           doctorsInstruction: ['doctorsInstruction is a required string'],
         },
       },


### PR DESCRIPTION
#### WHAT DOES THIS PR DO?
- Replaced `startVolume` and `stopVolume` with `volumeToDispense` in infusion schema.
- Update all affected infusion resources and tests to make use of `volumeToDispense`

#### RELEVANT PT STORY
- [#170123427](https://www.pivotaltracker.com/story/show/170123427)