### PR TITLE
#170501292 Allow the use of multiple status query parameters

### DIFF
--- a/src/db/infusion/index.js
+++ b/src/db/infusion/index.js
@@ -58,6 +58,13 @@ const getSingleInfusion = (infusionMatch) => {
  */
 const getAllInfusion = (infusionMatch) => {
   const Model = infusionModel;
+  const { status } = infusionMatch;
+  if (Array.isArray(status)) {
+    return Model.find({
+      ...infusionMatch,
+      $or: status.map(sta => ({ status: sta })),
+    });
+  }
   return Model.find(infusionMatch).select('-__v');
 };
 

--- a/src/http/controllers/infusion.js
+++ b/src/http/controllers/infusion.js
@@ -38,13 +38,13 @@ const createInfusion = catchControllerError('CreateInfusion', async (req, res) =
  */
 const getAllInfusion = catchControllerError('GetAllInfusion', async (req, res) => {
   const { user, userType, log } = res.locals;
-  const {
-    status, deviceId, wardId, nurseId,
-  } = req.query;
+
+  const requestData = validate(schemas.getAllInfusion, req);
+  if (requestData.error) return invalidReqeust(res, { errors: requestData.error });
+
   const infusions = await infusionService.getAllInfusion(
     {
-      // eslint-disable-next-line max-len
-      status, deviceId, wardId, nurseId, user, userType, populateFields: getPopulateFields(req.query.populate),
+      ...requestData.query, user, userType, populateFields: getPopulateFields(req.query.populate),
     }, log,
   );
   log.debug('getAllInfusion service executed without error, sending back a success response');

--- a/src/http/validations/schemas/infusion.js
+++ b/src/http/validations/schemas/infusion.js
@@ -36,3 +36,14 @@ export const getSingleInfusion = Joi.object({
 export const deleteInfusion = Joi.object({
   infusionId: getSingleInfusion.extract('infusionId'),
 });
+
+const infusionStatus = Joi.string().prefs({ convert: true }).lowercase().valid('active', 'ended', 'terminated');
+
+export const getAllInfusion = Joi.object({
+  query: {
+    status: [infusionStatus, Joi.array().items(infusionStatus)],
+    deviceId: common.validResourceId,
+    wardId: common.validResourceId,
+    nurseId: common.validResourceId,
+  },
+});

--- a/src/tests/infusion/getInfusion.test.js
+++ b/src/tests/infusion/getInfusion.test.js
@@ -45,10 +45,10 @@ const testCases = [
     },
   },
   {
-    title: 'should get all active infusions using url query',
+    title: 'should get all active and ended infusions using url query params',
     request: context => ({
       body: {},
-      path: '/api/infusion?status=active',
+      path: '/api/infusion?status=active&status=ended',
       method: 'get',
       headers: {
         'req-token': context.testGlobals[WARD_USER].authToken,


### PR DESCRIPTION
### What does this PR do?
- Add request validation for the different possible query parameters that can be used when fetching infusions
- Update getAllInfusions db query to be able to combine 2 or more status values for matching

### Related pivotal tracker story?
[#170501292](https://www.pivotaltracker.com/story/show/170501292)